### PR TITLE
Add basic React landing page

### DIFF
--- a/landing/.gitignore
+++ b/landing/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.dist
+.env
+.DS_Store

--- a/landing/README.md
+++ b/landing/README.md
@@ -1,0 +1,22 @@
+# NOVEX Landing Page
+
+Este proyecto es una landing page profesional, moderna y responsiva creada con React y Vite.
+
+## Desarrollo
+
+Para iniciar el entorno de desarrollo ejecuta:
+
+```bash
+npm install
+npm run dev
+```
+
+## Construcción
+
+Para generar los archivos de producción ejecuta:
+
+```bash
+npm run build
+```
+
+Luego puedes desplegarlos en SiteGround o cualquier otro hosting.

--- a/landing/index.html
+++ b/landing/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>NOVEX</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/landing/package.json
+++ b/landing/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "novex-landing",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.4.0"
+  }
+}

--- a/landing/src/App.css
+++ b/landing/src/App.css
@@ -1,0 +1,29 @@
+body {
+  margin: 0;
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+.App {
+  text-align: center;
+}
+
+.hero {
+  background: linear-gradient(135deg, #00bcd4, #0097a7);
+  color: white;
+  padding: 100px 20px;
+}
+
+.services,
+.about,
+.contact {
+  padding: 60px 20px;
+}
+
+.services ul {
+  list-style: none;
+  padding: 0;
+}
+
+.services li {
+  margin: 10px 0;
+}

--- a/landing/src/App.jsx
+++ b/landing/src/App.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import './App.css';
+
+function App() {
+  return (
+    <div className="App">
+      <header className="hero">
+        <h1>Bienvenido a NOVEX</h1>
+        <p>Soluciones tecnológicas a tu alcance</p>
+      </header>
+      <section className="services">
+        <h2>Servicios</h2>
+        <ul>
+          <li>Desarrollo de software a medida</li>
+          <li>Consultoría tecnológica</li>
+          <li>Soporte y mantenimiento</li>
+        </ul>
+      </section>
+      <section className="about">
+        <h2>Nosotros</h2>
+        <p>
+          En NOVEX nos especializamos en brindar soluciones innovadoras para
+          potenciar tu negocio.
+        </p>
+      </section>
+      <section className="contact">
+        <h2>Contacto</h2>
+        <p>Escríbenos a contacto@novex.com</p>
+      </section>
+    </div>
+  );
+}
+
+export default App;

--- a/landing/src/index.css
+++ b/landing/src/index.css
@@ -1,0 +1,4 @@
+/* Global styles */
+html, body, #root {
+  height: 100%;
+}

--- a/landing/src/main.jsx
+++ b/landing/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/landing/vite.config.js
+++ b/landing/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- initialize Vite-style React app under `landing`
- add Hero, Servicios, Nosotros and Contacto sections
- provide basic styling and README instructions

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688456938ddc8323bb6941d019fe100a